### PR TITLE
Picker workflow cleanup

### DIFF
--- a/client/templates/fulfillmentOrders/fulfillmentOrders.html
+++ b/client/templates/fulfillmentOrders/fulfillmentOrders.html
@@ -36,9 +36,10 @@
             <th>Ship By</th>
             <th class="hidden-xs hidden-sm">Arrival Day</th>
             <th class="hidden-xs hidden-sm">First Ski Day</th>
-            <th><i class="fa fa-map"></i></th>
+            <th>Customer</th>
+            <th>Destination</th>
             <th>Status</th>
-            <th>Current User</th>
+            <!-- <th>Current User</th> -->
           {{/if}}
         </tr>
       </thead>
@@ -70,7 +71,7 @@
         {{else}}
           <span class="label label-primary" style="font-size: 14px;">GROUND</span>
         {{/if}}
-      {{/if}}  
+      {{/if}}
     </td>
     {{#if startTime}}
       <td>{{shippingDate}}</td>
@@ -79,12 +80,8 @@
     {{else}}
       <td colspan=3>First Ski Day Missing!</td>
     {{/if}}
-    <td>{{shippingState}}</td>
-    <td>{{status}}</td> <!-- TODO: Add badge for statuses -->
-    {{#if readyForAssignment }}
-      <td><a class='btn btn-block btn-default advanceOrder' data-status='{{status}}' href='#'>Get Order</a></td>
-    {{else}}
-      <td>{{currentlyAssignedUser}}</td>
-    {{/if}}
+    <td>{{shippingName}}</td>
+    <td>{{shippingLoc}}</td>
+    <td>{{status}}</td>
   </tr>
 </template>

--- a/client/templates/fulfillmentOrders/fulfillmentOrders.html
+++ b/client/templates/fulfillmentOrders/fulfillmentOrders.html
@@ -23,6 +23,7 @@
                   <select class="form-control input-sm" id="bulkActions">
                     <option>Bulk Actions</option>
                     <option value="print">Print {{ordersSelected}} Orders</option>
+                    <option value="ship">Mark {{ordersSelected}} Orders as Shipped</option>
                   </select>
                 </div>
               </div>

--- a/client/templates/fulfillmentOrders/fulfillmentOrders.js
+++ b/client/templates/fulfillmentOrders/fulfillmentOrders.js
@@ -63,6 +63,8 @@ Template.fulfillmentOrders.events({
     if (event.currentTarget.value === 'print') {
       localStorage.selectedOrdersToPrint = JSON.stringify(Session.get('selectedOrders'));
       window.open(Router.url('orders.printSelected'));
+    } else if (event.currentTarget.value === 'ship') {
+      Meteor.call('advancedFulfillment/shipSelectedOrders', Session.get('selectedOrders'));
     }
   }
 });

--- a/client/templates/fulfillmentOrders/fulfillmentOrders.js
+++ b/client/templates/fulfillmentOrders/fulfillmentOrders.js
@@ -1,3 +1,12 @@
+let calendarFormat = {
+  sameDay: '[Today]',
+  nextDay: '[Tomorrow]',
+  nextWeek: 'dddd',
+  lastDay: '[Yesterday]',
+  lastWeek: '[Last] dddd',
+  sameElse: 'ddd MMM D, YYYY'
+};
+
 Template.fulfillmentOrders.onCreated(function () {
   Session.set('selectedOrders', []);
 });
@@ -66,21 +75,20 @@ Template.fulfillmentOrder.helpers({
     return '';
   },
   shippingDate: function () {
-    let longDate = this.advancedFulfillment.shipmentDate;
-    return moment(longDate).format('MMMM Do, YYYY');
+    return moment(this.advancedFulfillment.shipmentDate).calendar(null, calendarFormat);
   },
   arrivalDay: function () {
-    return moment(this.advancedFulfillment.arriveBy).format('MMMM Do, YYYY');
+    return moment(this.advancedFulfillment.arriveBy).calendar(null, calendarFormat);
   },
   firstSkiDay: function () {
-    return moment(this.startTime).format('MMMM Do, YYYY');
+    return moment(this.startTime).calendar(null, calendarFormat);
   },
   returningDate: function () {
     let longDate = this.advancedFulfillment.returnDate;
     return moment(longDate).format('MMMM Do, YYYY');
   },
-  shippingState: function () {
-    return this.shipping[0].address.region;
+  shippingLoc: function () {
+    return this.shipping[0].address.city + ', ' + this.shipping[0].address.region;
   },
   orderSelected: function () {
     // Session.setDefault('selectedOrders', []);
@@ -103,11 +111,8 @@ Template.fulfillmentOrder.helpers({
   contactInfo: function () {
     return this.email || 'Checked Out As Guest';
   },
-  names: function () {
-    return  {
-      shipping: this.shipping[0].address.fullName,
-      billing: this.shipping[0].address.fullName
-    };
+  shippingName: function () {
+    return this.shipping[0].address.fullName;
   },
   phoneNumber: function () {
     return this.shipping[0].address.phone || '';

--- a/client/templates/navbar/afNavbar.html
+++ b/client/templates/navbar/afNavbar.html
@@ -15,7 +15,7 @@
         <ul class="nav navbar-nav navbar-right">
           <form class="navbar-form navbar-left" role="search">
             <div class="form-group">
-              <input type="text" class="form-control" id='afSearchInput' placeholder="Search by Order Number/Id">
+              <input type="number" class="form-control" id='afSearchInput' placeholder="Search by Order Number/Id">
             </div>
             <button type="submit" id='afSearchButton' class="btn btn-default">Submit</button>
           </form>

--- a/client/templates/navbar/afNavbar.js
+++ b/client/templates/navbar/afNavbar.js
@@ -1,3 +1,7 @@
+Template.afNavbar.onCreated(function () {
+  this.subscribe('afOrders');
+});
+
 Template.afNavbar.onRendered(function () {
   $('.navbar-primary-tags').hide();
 });

--- a/client/templates/orderDetails/status/orderPicking/orderPicking.html
+++ b/client/templates/orderDetails/status/orderPicking/orderPicking.html
@@ -33,8 +33,13 @@
         </tbody>
       </table>
     </div>
-    <div>
-      <a class='btn btn-success btn-lg btn-block' id='all-items-picked' href="#">ALL Items Are Picked</a>
+    <div class="row">
+      <div class="col-xs-12 col-sm-6">
+        <a class='btn btn-success btn-lg btn-block' id='all-items-picked-new-order' href="#">All Items Picked - Get New Order</a>
+      </div>
+      <div class="col-xs-12 col-sm-6">
+        <a class='btn btn-info btn-lg btn-block' id='all-items-picked' href="#">All Items Picked</a>
+      </div>
     </div>
   </div>
 </template>

--- a/client/templates/orderDetails/status/orderPicking/orderPicking.js
+++ b/client/templates/orderDetails/status/orderPicking/orderPicking.js
@@ -97,5 +97,23 @@ Template.orderPicking.events({
         autoHide: false
       });
     }
+  },
+  'click #all-items-picked-new-order': function (event) {
+    event.preventDefault();
+    let orderId = this._id;
+    let userId = Meteor.userId();
+    let session = Session.get('orderPicking-' + orderId);
+    let allItemsPicked = _.every(session.itemStatus, function (item) {
+      return item === false;
+    });
+    if (allItemsPicked) {
+      Meteor.call('advancedFulfillment/updateOrderWorkflow', orderId, userId, 'orderPicking');
+      Router.go('advancedFulfillment.picker');
+    } else {
+      Alerts.removeSeen();
+      Alerts.add('All Items Have Not Been Picked', 'danger', {
+        autoHide: false
+      });
+    }
   }
 });

--- a/client/templates/picker/search.html
+++ b/client/templates/picker/search.html
@@ -5,7 +5,7 @@
       <div class="col-xs-12 col-md-4 col-md-offset-4">
         <form role="search" id="pickerSearch">
           <div class="form-group">
-            <input type="text" class="form-control input-lg" name="query" placeholder="Search by Order Number/Id">
+            <input type="number" class="form-control input-lg" name="query" placeholder="Search by Order Number/Id">
           </div>
           <button type="submit" id='pickerSearchSubmit' class="btn btn-lg btn-success btn-block">Submit</button>
         </form>

--- a/lib/advancedFulfillment.js
+++ b/lib/advancedFulfillment.js
@@ -48,8 +48,7 @@ AdvancedFulfillment.orderActive = [
   'orderPicked',
   'orderPacking',
   'orderPacked',
-  'orderReadyToShip',
-  'orderShipped'
+  'orderReadyToShip'
 ];
 
 AdvancedFulfillment.orderReturning = [

--- a/package.js
+++ b/package.js
@@ -38,8 +38,9 @@ Package.onUse(function (api) {
     'server/hooks/after_copyCartToOrder.js',
     'server/methods/orderDetail.js',
     'server/methods/itemDetails.js',
-    'server/publications/afOrders.js',
-    'server/methods/customerService.js'
+    'server/methods/customerService.js',
+    'server/methods/bulkActions.js',
+    'server/publications/afOrders.js'
   ], 'server');
 
   api.addFiles([

--- a/server/methods/bulkActions.js
+++ b/server/methods/bulkActions.js
@@ -1,0 +1,17 @@
+Meteor.methods({
+  'advancedFulfillment/shipSelectedOrders': function (orderIds) {
+    check(orderIds, [Match.Any]);
+    // if (!ReactionCore.hasPermission('reaction-advanced-fulfillment')) {
+    //   throw new Meteor.Error(403, 'Access Denied');
+    // }
+    console.log(orderIds);
+    this.unblock();
+    _.each(orderIds, function (orderId) {
+      let order = ReactionCore.Collections.Orders.findOne(orderId);
+      let currentStatus = order.advancedFulfillment.workflow.status;
+      if (currentStatus === 'orderReadyToShip') {
+        Meteor.call('advancedFulfillment/updateOrderWorkflow', order._id, Meteor.userId(), currentStatus);
+      }
+    });
+  }
+});

--- a/server/publications/afOrders.js
+++ b/server/publications/afOrders.js
@@ -18,7 +18,8 @@ Meteor.publish('afOrders', function () {
         // 'shipping.address.phone': 1,
         'history': 1,
         'shipping.address.region': 1,
-        // 'shipping.address.fullName': 1,
+        'shipping.address.city': 1,
+        'shipping.address.fullName': 1,
         // 'billing.address.fullName': 1,
         'advancedFulfillment.localDelivery': 1,
         'advancedFulfillment.rushDelivery': 1,
@@ -26,7 +27,6 @@ Meteor.publish('afOrders', function () {
         'advancedFulfillment.kayakRental.qty': 1,
         'advancedFulfillment.rushShippingPaid': 1
       }
-
     });
   }
   return this.ready();


### PR DESCRIPTION
Picker and Dashboard workflow cleanup
- Redirect button to picker search page on completed pick
- Fixes bug where navbar search was not subscribed to all orders
- Format dates as `moment.calendar()` time (e.g. Today, Tomorrow, Thursday)
- Bulk mark as Shipped functionality
- Remove orders with status `orderShipped` from activeOrders status array
- Set search input field to type='number' so that number pad comes up on mobile devices by default.
