### PR TITLE
Return fix

### DIFF
--- a/client/templates/fulfillmentOrders/returnOrders.html
+++ b/client/templates/fulfillmentOrders/returnOrders.html
@@ -1,0 +1,75 @@
+<template name='returnOrders'>
+  {{> afNavbar}}
+  <div class='container-fluid'>
+    <div class='col-md-9 col-sm-12'>
+      <h1>Orders waiting to be Returned</h1>
+    </div>
+    <table class='table table-hover'>
+      <thead>
+        {{#if ordersAreSelected}}
+          <th colspan="9">
+            <div class="row">
+              <div class="col-xs-7 col-sm-3 col-md-2">
+                <i class="fa fa-check-square-o fa-lg" style="cursor: pointer;" id="checkboxAllOrders"></i>
+                {{ordersSelected}} Selected Orders
+              </div>
+              <div class="col-xs-5 col-sm-2 col-md-2">
+                <select class="form-control input-sm" id="bulkActions">
+                  <option>Bulk Actions</option>
+                  <option value="return">Mark {{ordersSelected}} Orders as Returned</option>
+                  <option value="complete">Mark {{ordersSelected}} Orders as Completed</option>
+                  {{status}}
+                </select>
+              </div>
+            </div>
+          </th>
+        {{else}}
+          <th>
+            <i class="fa fa-square-o fa-lg" style="cursor: pointer;" id="checkboxAllOrders"></i>
+          </th>
+          <th>#</th>
+          <th><i class='fa fa-truck'></i></th>
+          <th>Expected Return On</th>
+          <th class="hidden-xs hidden-sm">Customer Ship for Return</th>
+          <th class="hidden-xs hidden-sm">Last Ski Day</th>
+          <th>Customer</th>
+          <th>Returning From</th>
+          <th>Status</th>
+        {{/if}}
+      </thead>
+      <tbody>
+        {{#each orders}}
+          {{> returnOrder}}
+        {{/each}}
+      </tbody>
+    </table>
+  </div>
+</template>
+
+<template name='returnOrder'>
+  <tr class="orderRow" style="cursor: pointer;" data-id='{{_id}}'>
+    <td class="no-click">
+      {{#if orderSelected}}
+        <input type="checkbox" name="order_{{_id}}" id="checkboxOrder_{{_id}}" class="hide" data-id={{_id}} checked=checked><label for="order_{{_id}}" style="cursor: pointer;"><i class="fa fa-check-square-o fa-lg"></i></label>
+      {{else}}
+        <input type="checkbox" name="order_{{_id}}" id="checkboxOrder_{{_id}}" class="hide" data-id={{_id}}><label for="order_{{_id}}" style="cursor: pointer;"><i class="fa fa-square-o fa-lg"></i></label>
+      {{/if}}
+    </td>
+    <td><strong>{{orderNumber}}</strong></td>
+    <td>
+      {{#if advancedFulfillment.localDelivery}}
+        <span class="label label-info" style="font-size: 14px;">LOCAL</span>
+      {{else}}
+        <span class="label label-primary" style="font-size: 14px;">GROUND</span>
+      {{/if}}
+    </td>
+    <td>
+      {{returningDate}}
+    </td>
+    <td class="hidden-xs hidden-sm">{{shippingDay}}</td>
+    <td class="hidden-xs hidden-sm">{{lastSkiDay}}</td>
+    <td>{{returnName}}</td>
+    <td>{{shippingLoc}}</td>
+    <td>{{status}}</td>
+  </tr>
+</template>

--- a/client/templates/fulfillmentOrders/returnOrders.js
+++ b/client/templates/fulfillmentOrders/returnOrders.js
@@ -24,9 +24,9 @@ Template.returnOrders.events({
   },
   'change #bulkActions': function (event) {
     if (event.currentTarget.value === 'return') {
-      debugger;
       Meteor.call('advancedFulfillment/returnSelectedOrders', Session.get('returnOrders'));
     } else if (event.currentTarget.value === 'complete') {
+      Meteor.call('advancedFulfillment/completeSelectedOrders', Session.get('returnOrders'));
     }
     Session.set('returnOrders', []);
   }

--- a/client/templates/fulfillmentOrders/returnOrders.js
+++ b/client/templates/fulfillmentOrders/returnOrders.js
@@ -1,0 +1,85 @@
+Template.returnOrders.onCreated(function () {
+  Session.setDefault('returnOrders', []);
+});
+
+Template.returnOrders.helpers({
+  ordersSelected: function () {
+    return Session.get('returnOrders').length;
+  },
+  ordersAreSelected: function () {
+    return Session.get('returnOrders').length > 0;
+  }
+});
+
+Template.returnOrders.events({
+  'click #checkboxAllOrders': function () {
+    const checked = Session.get('returnOrders').length > 0;
+    let returnOrders = [];
+    $('input[type=checkbox]').prop('checked', !checked);
+
+    $('input[type=checkbox]:checked').each(function () {
+      returnOrders.push($(this).data('id'));
+    });
+    Session.set('returnOrders', returnOrders);
+  },
+  'change #bulkActions': function (event) {
+    if (event.currentTarget.value === 'return') {
+      debugger;
+      Meteor.call('advancedFulfillment/returnSelectedOrders', Session.get('returnOrders'));
+    } else if (event.currentTarget.value === 'complete') {
+    }
+    Session.set('returnOrders', []);
+  }
+});
+
+Template.returnOrder.helpers({
+  orderNumber: function  () {
+    if (this.shopifyOrderNumber) {
+      return '#' + this.shopifyOrderNumber + ' ';
+    }
+    return '';
+  },
+  orderSelected: function () {
+    // Session.setDefault('selectedOrders', []);
+    return Session.get('returnOrders').indexOf(this._id) !== -1;
+  },
+  returningDate: function () {
+    return moment(this.advancedFulfillment.returnDate).calendar(null, AdvancedFulfillment.calendarReferenceTime);
+  },
+  shippingDay: function () {
+    return moment(this.advancedFulfillment.shipReturnBy).calendar(null, AdvancedFulfillment.calendarReferenceTime);
+  },
+  lastSkiDay: function () {
+    return moment(this.endTime).calendar(null, AdvancedFulfillment.calendarReferenceTime);
+  },
+  returnName: function () {
+    return this.shipping[0].address.fullName;
+  },
+  shippingLoc: function () {
+    return this.shipping[0].address.city + ', ' + this.shipping[0].address.region;
+  },
+  status: function () {
+    return AdvancedFulfillment.humanOrderStatuses[this.advancedFulfillment.workflow.status];
+  }
+});
+
+Template.returnOrder.events({
+  'click .orderRow': function (event) {
+    Router.go('orderDetails', {_id: $(event.currentTarget).data('id')});
+  },
+  'click label .fa-check-square-o, click label .fa-square-o': function (event) {
+    event.stopPropagation();
+    event.stopImmediatePropagation();
+    const checked = $(event.currentTarget).parent().prev()[0].checked;
+    $(event.currentTarget).parent().prev()[0].checked = !checked;
+    const _id = $(event.currentTarget).parent().prev().data('id');
+    let returnOrders = Session.get('returnOrders');
+    if (!checked) {
+      returnOrders.push(_id);
+    } else {
+      returnOrders = _.without(returnOrders, _id);
+    }
+
+    Session.set('returnOrders', returnOrders);
+  }
+});

--- a/client/templates/orderDetails/orderDetails.js
+++ b/client/templates/orderDetails/orderDetails.js
@@ -170,6 +170,9 @@ Template.orderDetails.events({
     let currentStatus = this.advancedFulfillment.workflow.status;
     let orderId = this._id;
     let userId = Meteor.userId();
+    if (currentStatus === 'orderShipped') {
+      Meteor.call('advancedFulfillment/updateAllItemsToSpecificStatus', this, 'shipped');
+    }
     Meteor.call('advancedFulfillment/updateOrderWorkflow', orderId, userId, currentStatus);
   },
   'blur .notes': function (event) {

--- a/common/router.js
+++ b/common/router.js
@@ -317,10 +317,10 @@ Router.route('dashboard/advanced-fulfillment/orders/status/:status', {
 
 Router.route('dashboard/advanced-fulfillment/returns', {
   name: 'returns',
-  template: 'fulfillmentOrders',
+  template: 'returnOrders',
   controller: advancedFulfillmentController,
   waitOn: function () {
-    return this.subscribe('afOrders');
+    return this.subscribe('afReturnOrders');
   },
   data: function () {
     return {orders: ReactionCore.Collections.Orders.find({

--- a/lib/advancedFulfillment.js
+++ b/lib/advancedFulfillment.js
@@ -24,9 +24,10 @@ AdvancedFulfillment.humanOrderStatuses = {
   'orderReadyToShip': 'Labeled',
   'orderShipped': 'Shipped',
   'orderReturned': 'Returned',
-  'orderComplete': 'Complete',
+  'orderCompleted': 'Complete',
   'orderIncomplete': 'Incomplete',
-  'nonWarehouseOrder': 'nonWarehouseOrder'
+  'nonWarehouseOrder': 'nonWarehouseOrder',
+  'orderCancelled': 'Cancelled'
 };
 
 AdvancedFulfillment.workflow = [

--- a/package.js
+++ b/package.js
@@ -49,6 +49,8 @@ Package.onUse(function (api) {
     'client/templates/settings/settings.js',
     'client/templates/fulfillmentOrders/fulfillmentOrders.html',
     'client/templates/fulfillmentOrders/fulfillmentOrders.js',
+    'client/templates/fulfillmentOrders/returnOrders.html',
+    'client/templates/fulfillmentOrders/returnOrders.js',
     'client/templates/dashboard/dashboard.html',
     'client/templates/dashboard/dashboard.js',
     'client/templates/orderDetails/orderDetails.html',

--- a/server/methods/bulkActions.js
+++ b/server/methods/bulkActions.js
@@ -40,5 +40,18 @@ Meteor.methods({
         Meteor.call('advancedFulfillment/updateOrderWorkflow', order._id, Meteor.userId(), currentStatus);
       }
     });
+  },
+  'advancedFulfillment/returnSelectedOrders': function (orderIds) {
+    check(orderIds, [String]);
+    this.unblock();
+    _.each(orderIds, function (orderId) {
+      console.log('order-', orderId);
+      let order = ReactionCore.Collections.Orders.findOne(orderId);
+      let currentStatus = order.advancedFulfillment.workflow.status;
+      if (currentStatus === 'orderShipped') {
+        Meteor.call('advancedFulfillment/updateAllItemsToSpecificStatus', order, 'shipped');
+        Meteor.call('advancedFulfillment/updateOrderWorkflow', order._id, Meteor.userId(), currentStatus);
+      }
+    });
   }
 });

--- a/server/methods/bulkActions.js
+++ b/server/methods/bulkActions.js
@@ -45,12 +45,22 @@ Meteor.methods({
     check(orderIds, [String]);
     this.unblock();
     _.each(orderIds, function (orderId) {
-      console.log('order-', orderId);
       let order = ReactionCore.Collections.Orders.findOne(orderId);
       let currentStatus = order.advancedFulfillment.workflow.status;
       if (currentStatus === 'orderShipped') {
         Meteor.call('advancedFulfillment/updateAllItemsToSpecificStatus', order, 'shipped');
         Meteor.call('advancedFulfillment/updateOrderWorkflow', order._id, Meteor.userId(), currentStatus);
+      }
+    });
+  },
+  'advancedFulfillment/completeSelectedOrders': function (orderIds) {
+    check(orderIds, [String]);
+    this.unblock();
+    _.each(orderIds, function (orderId) {
+      let order = ReactionCore.Collections.Orders.findOne(orderId);
+      let currentStatus = order.advancedFulfillment.workflow.status;
+      if (currentStatus === 'orderShipped' || currentStatus === 'orderReturned') {
+        Meteor.call('advancedFulfillment/bypassWorkflowAndComplete', order._id, Meteor.userId());
       }
     });
   }

--- a/server/methods/customerService.js
+++ b/server/methods/customerService.js
@@ -3,7 +3,7 @@ Meteor.methods({
     check(orderId, String);
     check(userId, String);
     let history = {
-      event: 'orderCanceled',
+      event: 'orderCancel;ed',
       userId: userId,
       updatedAt: new Date()
     };
@@ -14,7 +14,7 @@ Meteor.methods({
         history: history
       },
       $set: {
-        'advancedFulfillment.workflow.status': 'orderCanceled',
+        'advancedFulfillment.workflow.status': 'orderCancelled',
         'advancedFulfillment.impossibleShipDate': false
       }
     });

--- a/server/methods/itemDetails.js
+++ b/server/methods/itemDetails.js
@@ -78,5 +78,20 @@ Meteor.methods({
       }
     });
     return ReactionCore.Collections.Orders.findOne(orderId);
+  },
+  'advancedFulfillment/updateAllItemsToSpecificStatus': function (order, desiredItemStatus) {
+    check(order, Object);
+    check(desiredItemStatus, String);
+    let items = order.advancedFulfillment.items;
+    _.each(items, function (item) {
+      item.workflow.status = desiredItemStatus;
+    });
+    ReactionCore.Collections.Orders.update({
+      _id: order._id
+    }, {
+      $set: {
+        'advancedFulfillment.items': items
+      }
+    });
   }
 });

--- a/server/methods/orderDetail.js
+++ b/server/methods/orderDetail.js
@@ -472,5 +472,32 @@ Meteor.methods({
         'advancedFulfillment.items': newAfItem
       }
     });
+  },
+  'advancedFulfillment/bypassWorkflowAndComplete': function (orderId, userId) {
+    check(orderId, String);
+    check(userId, String);
+    let history = [
+      {
+        event: 'bypassedWorkFlowToComplete',
+        userId: userId,
+        updatedAt: new Date()
+      }, {
+        event: 'orderCompleted',
+        userId: userId,
+        updatedAt: new Date()
+      }
+    ];
+    ReactionCore.Collections.Orders.update({
+      _id: orderId
+    }, {
+      $set: {
+        'advancedFulfillment.workflow.status': 'orderCompleted'
+      },
+      $addToSet: {
+        history: {
+          $each: history
+        }
+      }
+    });
   }
 });

--- a/server/publications/afOrders.js
+++ b/server/publications/afOrders.js
@@ -136,3 +136,16 @@ Meteor.publish('custServOrders', function () {
   }
   return this.ready();
 });
+
+Meteor.publish('afReturnOrders', function () {
+  shopId = ReactionCore.getShopId();
+  if (Roles.userIsInRole(this.userId, ['admin', 'owner', 'dashboard/advanced-fulfillment', 'reaction-advanced-fulfillment'], ReactionCore.getShopId())) {
+    return ReactionCore.Collections.Orders.find({
+      'shopId': shopId,
+      'advancedFulfillment.workflow.status': {
+        $in: AdvancedFulfillment.orderReturning
+      }
+    });
+  }
+  return this.ready();
+});

--- a/server/publications/afOrders.js
+++ b/server/publications/afOrders.js
@@ -145,6 +145,25 @@ Meteor.publish('afReturnOrders', function () {
       'advancedFulfillment.workflow.status': {
         $in: AdvancedFulfillment.orderReturning
       }
+    }, {
+      fields: {
+        'endTime': 1,
+        'advancedFulfillment.returnDate': 1,
+        'advancedFulfillment.workflow.status': 1,
+        'advancedFulfillment.items._id': 1,
+        'advancedFulfillment.items.workflow': 1,
+        'advancedFulfillment.shipReturnBy': 1,
+        'shopifyOrderNumber': 1,
+        'history': 1,
+        'shipping.address.region': 1,
+        'shipping.address.city': 1,
+        'shipping.address.fullName': 1,
+        'advancedFulfillment.localDelivery': 1,
+        'advancedFulfillment.rushDelivery': 1,
+        'advancedFulfillment.kayakRental.vendor': 1,
+        'advancedFulfillment.kayakRental.qty': 1,
+        'advancedFulfillment.rushShippingPaid': 1
+      }
     });
   }
   return this.ready();


### PR DESCRIPTION
@spencern one thing that should be mentioned before review. When an order is marked as orderReturned, the items have to be in Shipped status to mark them as Damaged, Missing or Returned. Because now, we have a system that can push orders at any stage to labeled and shipped. I made it so when you bulk order or click 'Returned' button, it also updates each item to shipped. 

Other items in this pr:
- Bulk action Return Orders
- Bulk action Complete orders (with a special history object, that says this order was completed by bypassing, so we can see how often this is done)
- Redesigned page to display relevent return info
- Created publication to increase speed of pulling in orders, without excess data
