### PR TITLE
Don't filter out orders that have no 'warehouse' items by default.

### DIFF
--- a/client/templates/helpers.js
+++ b/client/templates/helpers.js
@@ -30,7 +30,7 @@ Template.registerHelper('hasCustomerServiceIssue', (order) => {
     order.itemMissingDetails,
     order.bundleMissingColor,
     order.advancedFulfillment.impossibleShipDate,
-    order.items.length === 0
+    order.advancedFulfillment.items.length === 0
   ];
   return _.some(anyIssues);
 });

--- a/client/templates/helpers.js
+++ b/client/templates/helpers.js
@@ -29,7 +29,8 @@ Template.registerHelper('hasCustomerServiceIssue', (order) => {
     order.infoMissing,
     order.itemMissingDetails,
     order.bundleMissingColor,
-    order.advancedFulfillment.impossibleShipDate
+    order.advancedFulfillment.impossibleShipDate,
+    order.items.length === 0
   ];
   return _.some(anyIssues);
 });

--- a/common/router.js
+++ b/common/router.js
@@ -44,7 +44,6 @@ Router.route('dashboard/advanced-fulfillment', {
   },
   data: function () {
     return {orders: ReactionCore.Collections.Orders.find({
-      'items': {$ne: []},
       'advancedFulfillment.workflow.status': {
         $in: AdvancedFulfillment.orderActive
       },


### PR DESCRIPTION
Flag them as 'hasCustomerServiceIssue' instead.
