### PR TITLE
Fix dashboard publication so that it shows all orders.

### DIFF
--- a/server/publications/afOrders.js
+++ b/server/publications/afOrders.js
@@ -74,7 +74,6 @@ Meteor.publish('shippingOrders', function () {
   if (Roles.userIsInRole(this.userId, AdvancedFulfillment.server.permissions, ReactionCore.getShopId())) {
     return ReactionCore.Collections.Orders.find({
       'shopId': shopId,
-      'items': {$ne: []},
       'advancedFulfillment.workflow.status': {
         $in: AdvancedFulfillment.orderShipping
       },


### PR DESCRIPTION
We had adjusted the subscription in the route, but hadn't fixed the publication yet. This fixes the publication `shippingOrders` so that it publishes orders that don't have matched items as well.
