### PR TITLE
Bundled Products, Slack Integration and Terms of Service check

### DIFF
--- a/client/templates/settings/settings.html
+++ b/client/templates/settings/settings.html
@@ -20,6 +20,7 @@
 
     <p>Enable Slack</p>
     {{>afQuickField  name='settings.slack'}}
+    {{>afQuickField  name='settings.slackChannel'}}
     <button type="submit" class="btn btn-primary pull-right">Save Changes</button>
       {{/autoForm}}
   </div>

--- a/client/templates/settings/settings.html
+++ b/client/templates/settings/settings.html
@@ -17,6 +17,9 @@
     {{>afQuickField  name='settings.aftership.preSharedKey'}}
     <p>Enable Klaviyo</p>
     {{>afQuickField  name='settings.klaviyo'}}
+
+    <p>Enable Slack</p>
+    {{>afQuickField  name='settings.slack'}}
     <button type="submit" class="btn btn-primary pull-right">Save Changes</button>
       {{/autoForm}}
   </div>

--- a/common/collections.js
+++ b/common/collections.js
@@ -42,6 +42,11 @@ ReactionCore.Schemas.AdvancedFulfillmentPackageConfig = new SimpleSchema([
     'settings.slack': {
       type: Boolean,
       label: 'Enable Slack Messaging'
+    },
+    'settings.slackChannel': {
+      type: String,
+      label: 'Choose Slack Channel to Post In',
+      optional: true
     }
   }
 ]);

--- a/common/collections.js
+++ b/common/collections.js
@@ -38,6 +38,10 @@ ReactionCore.Schemas.AdvancedFulfillmentPackageConfig = new SimpleSchema([
     'settings.klaviyo': {
       type: Boolean,
       label: 'Enable Klaviyo Event Triggers'
+    },
+    'settings.slack': {
+      type: Boolean,
+      label: 'Enable Slack Messaging'
     }
   }
 ]);

--- a/package.js
+++ b/package.js
@@ -47,7 +47,8 @@ Package.onUse(function (api) {
     'server/methods/bulkActions.js',
     'server/methods/aftership.js',
     'server/publications/afOrders.js',
-    'server/methods/klaviyo.js'
+    'server/methods/klaviyo.js',
+    'server/methods/slack.js'
   ], 'server');
 
   api.addFiles([

--- a/server/hooks/after_copyCartToOrder.js
+++ b/server/hooks/after_copyCartToOrder.js
@@ -65,6 +65,9 @@ ReactionCore.MethodHooks.after('cart/copyCartToOrder', function (options) {
   if (afPackage.settings.klaviyo && order.email) {
     Meteor.call('advancedFulfullment/createKlaviyoGeneralEvent', orderId, 'Checkout');
   }
+  if (afPackage.settings.slack) {
+    Meteor.call('advancedFulfullment/slackMessage', orderId);
+  }
 
   return orderId;
 });

--- a/server/hooks/after_copyCartToOrder.js
+++ b/server/hooks/after_copyCartToOrder.js
@@ -65,8 +65,8 @@ ReactionCore.MethodHooks.after('cart/copyCartToOrder', function (options) {
   if (afPackage.settings.klaviyo && order.email) {
     Meteor.call('advancedFulfullment/createKlaviyoGeneralEvent', orderId, 'Checkout');
   }
-  if (afPackage.settings.slack) {
-    Meteor.call('advancedFulfullment/slackMessage', orderId);
+  if (afPackage.settings.slack && afPackage.settings.slackChannel) {
+    Meteor.call('advancedFulfullment/slackMessage', orderId, afPackage.settings.slackChannel);
   }
 
   return orderId;

--- a/server/methods/slack.js
+++ b/server/methods/slack.js
@@ -7,7 +7,7 @@ Meteor.methods({
       let start = moment(order.startTime).format('M/D/YY');
       let end = moment(order.endTime).format('M/D/YY');
       let orderNumber = `Order #${order.orderNumber} items: `;
-      let orderLink = `https://getoutfitted.com/dashboard/advanced-fulfillment/order/${order._id}`;
+      let orderLink = `${process.env.ROOT_URL}/dashboard/advanced-fulfillment/order/${order._id}`;
       let orderText = `Order #${order.orderNumber} placed by: ${order.billing[0].address.fullName}
         Placed on: ${moment(order.createdAt).format('M/D/YY')}
         Rental Dates: ${start}-${end}

--- a/server/methods/slack.js
+++ b/server/methods/slack.js
@@ -8,19 +8,20 @@ Meteor.methods({
       let end = moment(order.endTime).format('M/D/YY');
       let orderNumber = `Order #${order.orderNumber} items: `;
       let orderLink = `${process.env.ROOT_URL}/dashboard/advanced-fulfillment/order/${order._id}`;
-      let orderText = `Order #${order.orderNumber} placed by: ${order.billing[0].address.fullName}
+      let orderText = `*Order #${order.orderNumber}* placed by: ${order.billing[0].address.fullName}
         Placed on: ${moment(order.createdAt).format('M/D/YY')}
         Rental Dates: ${start}-${end}
         Contact Email: ${order.email}
         Contact Phone: ${order.billing[0].address.phone}
         Shipping To: ${order.shipping[0].address.city}, ${order.shipping[0].address.region}
-        Order Total: $ ${order.billing[0].invoice.total}`;
+        *Order Total: $ ${order.billing[0].invoice.total}*`;
       let slackPost = {
         channel: 'sales',
         text: orderText,
         icon_url: 'https://cdn0.iconfinder.com/data/icons/kameleon-free-pack-rounded/110/Money-Increase-128.png',
         as_user: false,
-        username: 'sales_bot'
+        username: 'sales_bot',
+        mrkdwn: true
       };
 
       let attachments = {

--- a/server/methods/slack.js
+++ b/server/methods/slack.js
@@ -1,0 +1,44 @@
+Meteor.methods({
+  'advancedFulfullment/slackMessage': function (orderId) {
+    check(orderId, String);
+    // TODO : Lock down from client calling method:
+    const order = ReactionCore.Collections.Orders.findOne(orderId);
+    if (order) {
+      let start = moment(order.startTime).format('M/D/YY');
+      let end = moment(order.endTime).format('M/D/YY');
+      let orderNumber = `Order #${order.orderNumber} items: `;
+      let orderLink = `https://getoutfitted.com/dashboard/advanced-fulfillment/order/${order._id}`;
+      let orderText = `Order #${order.orderNumber} placed by: ${order.billing[0].address.fullName}
+        Placed on: ${moment(order.createdAt).format('M/D/YY')}
+        Rental Dates: ${start}-${end}
+        Contact Email: ${order.email}
+        Contact Phone: ${order.billing[0].address.phone}
+        Shipping To: ${order.shipping[0].address.city}, ${order.shipping[0].address.region}
+        Order Total: $ ${order.billing[0].invoice.total}`;
+      let slackPost = {
+        channel: 'sales',
+        text: orderText,
+        icon_url: 'https://cdn0.iconfinder.com/data/icons/kameleon-free-pack-rounded/110/Money-Increase-128.png',
+        as_user: false,
+        username: 'sales_bot'
+      };
+
+      let attachments = {
+        title: orderNumber,
+        title_link: orderLink,
+        color: '#3AA5BE'
+      };
+      let fields = _.map(order.items, function (item) {
+        let field = {
+          title: item.variants.sku,
+          value: 'Qty:' + item.quantity,
+          short: true
+        };
+        return field;
+      });
+      attachments.fields = fields;
+
+      Slack.PostMessage(slackPost, [attachments]);
+    }
+  }
+});

--- a/server/methods/slack.js
+++ b/server/methods/slack.js
@@ -7,7 +7,7 @@ Meteor.methods({
       let start = moment(order.startTime).format('M/D/YY');
       let end = moment(order.endTime).format('M/D/YY');
       let orderNumber = `Order #${order.orderNumber} items: `;
-      let orderLink = `${process.env.ROOT_URL}/dashboard/advanced-fulfillment/order/${order._id}`;
+      let orderLink = `${process.env.ROOT_URL}dashboard/advanced-fulfillment/order/${order._id}`;
       let orderText = `*Order #${order.orderNumber}* placed by: ${order.billing[0].address.fullName}
         Placed on: ${moment(order.createdAt).format('M/D/YY')}
         Rental Dates: ${start}-${end}

--- a/server/methods/slack.js
+++ b/server/methods/slack.js
@@ -1,6 +1,7 @@
 Meteor.methods({
-  'advancedFulfullment/slackMessage': function (orderId) {
+  'advancedFulfullment/slackMessage': function (orderId, channel) {
     check(orderId, String);
+    check(channel, String);
     // TODO : Lock down from client calling method:
     const order = ReactionCore.Collections.Orders.findOne(orderId);
     if (order) {
@@ -16,7 +17,7 @@ Meteor.methods({
         Shipping To: ${order.shipping[0].address.city}, ${order.shipping[0].address.region}
         *Order Total: $ ${order.billing[0].invoice.total}*`;
       let slackPost = {
-        channel: 'sales',
+        channel: channel,
         text: orderText,
         icon_url: 'https://cdn0.iconfinder.com/data/icons/kameleon-free-pack-rounded/110/Money-Increase-128.png',
         as_user: false,


### PR DESCRIPTION
## Feature Launch - Bundled Products, Slack Integration and Terms of Service check
### Features Launched In this Updated
- **Bundle Products** - Customer can now check out with one Product and it will behind the scenes track multople items inventory
- **Blocked ability to checkout with incompatible rental lengths**. - Example can't checkout with Demo product (6 or 12 day rentals) and Camping Rental of 5 days
- **Product Bundler Package** - Now you can create a Bundle giving it name and attirbutes, plus add existing products to that bundle
- **Waiver** - On customer checkout, you must click a checkbox before you are able to checkout
- **Slack Package** - Now you can set up slack so that it posts to a specific channel when an order is placed.
